### PR TITLE
Feature: unique name filtering for call interceptors

### DIFF
--- a/source/Zyan.Communication/CallInterceptionData.cs
+++ b/source/Zyan.Communication/CallInterceptionData.cs
@@ -22,11 +22,13 @@ namespace Zyan.Communication
 		/// <summary>
 		/// Creates a new instance of the CallInterceptionData class.
 		/// </summary>
+		/// <param name="invokerName">Inform interceptor about proxy unique name.</param>
 		/// <param name="parameters">Parameter values of the intercepted call</param>
 		/// <param name="remoteInvoker">Delegate for remote invocation</param>
 		/// <param name="remotingMessage">Remoting message</param>
-		public CallInterceptionData(object[] parameters, InvokeRemoteMethodDelegate remoteInvoker, IMethodCallMessage remotingMessage)
+		public CallInterceptionData(string invokerName, object[] parameters, InvokeRemoteMethodDelegate remoteInvoker, IMethodCallMessage remotingMessage)
 		{
+			InvokerUniqueName = invokerName;
 			Intercepted = false;
 			ReturnValue = null;
 			Parameters = parameters;
@@ -52,6 +54,11 @@ namespace Zyan.Communication
 
 			return null;
 		}
+
+		/// <summary>
+		/// Proxy caller name.
+		/// </summary>
+		public string InvokerUniqueName { get; }
 
 		/// <summary>
 		/// Gets or sets wether the call was intercepted.

--- a/source/Zyan.Communication/CallInterceptor.cs
+++ b/source/Zyan.Communication/CallInterceptor.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Linq;
 using System.Reflection;
+using System.Text.RegularExpressions;
 using Zyan.Communication.Toolbox;
 
 namespace Zyan.Communication
@@ -28,7 +29,7 @@ namespace Zyan.Communication
 		public CallInterceptor(Type interfaceType, string uniqueName, MemberTypes memberType, string memberName, Type[] parameterTypes, CallInterceptionDelegate onInterception)
 		{
 			InterfaceType = interfaceType;
-			UniqueNameFilter = string.IsNullOrEmpty(uniqueName) ? interfaceType.FullName : uniqueName;
+			UniqueNameFilter = string.IsNullOrEmpty(uniqueName) ? Regex.Escape(interfaceType.FullName) : uniqueName;
 			MemberType = memberType;
 			MemberName = memberName;
 			ParameterTypes = parameterTypes;

--- a/source/Zyan.Communication/CallInterceptor.cs
+++ b/source/Zyan.Communication/CallInterceptor.cs
@@ -51,6 +51,19 @@ namespace Zyan.Communication
 		}
 
 		/// <summary>
+		/// Compare unique name via regex.
+		/// </summary>
+		/// <param name="name"></param>
+		/// <returns></returns>
+		public bool IsNameMatch(string name)
+		{
+			// performance optimization
+			if (name == UniqueNameFilter)
+				return true;
+			return Regex.IsMatch(name, UniqueNameFilter);
+		}
+
+		/// <summary>
 		/// Gets the interface type of the intercepted component.
 		/// </summary>
 		public Type InterfaceType { get; private set; }

--- a/source/Zyan.Communication/CallInterceptor.cs
+++ b/source/Zyan.Communication/CallInterceptor.cs
@@ -28,7 +28,7 @@ namespace Zyan.Communication
 		public CallInterceptor(Type interfaceType, string uniqueName, MemberTypes memberType, string memberName, Type[] parameterTypes, CallInterceptionDelegate onInterception)
 		{
 			InterfaceType = interfaceType;
-			UniqueName = string.IsNullOrEmpty(uniqueName) ? interfaceType.FullName : uniqueName;
+			UniqueNameFilter = string.IsNullOrEmpty(uniqueName) ? interfaceType.FullName : uniqueName;
 			MemberType = memberType;
 			MemberName = memberName;
 			ParameterTypes = parameterTypes;
@@ -55,9 +55,9 @@ namespace Zyan.Communication
 		public Type InterfaceType { get; private set; }
 
 		/// <summary>
-		/// Gets the unique name of intercepted component.
+		/// Gets the unique name filter of intercepted component.
 		/// </summary>
-		public string UniqueName { get; private set; }
+		public string UniqueNameFilter { get; internal set; }
 
 		/// <summary>
 		/// Gets the Type of the intercepted member.
@@ -138,6 +138,17 @@ namespace Zyan.Communication
 			}
 
 			return string.Format("{0}.{1}{2}", InterfaceType, MemberName, parameters);
+		}
+
+		/// <summary>
+		/// Filters unique name over regex.
+		/// </summary>
+		/// <param name="nameFilter"></param>
+		/// <returns></returns>
+		public CallInterceptor WithUniqueNameFilter(string nameFilter)
+		{
+			UniqueNameFilter = nameFilter;
+			return this;
 		}
 	}
 }

--- a/source/Zyan.Communication/CallInterceptorBuilder.cs
+++ b/source/Zyan.Communication/CallInterceptorBuilder.cs
@@ -18,7 +18,7 @@ namespace Zyan.Communication
 		/// <param name="uniqueName">Unique name of the intercepted component.</param>
 		public CallInterceptorBuilder(string uniqueName)
 		{
-			UniqueName = string.IsNullOrEmpty(uniqueName) ? typeof(T).FullName : uniqueName;
+			UniqueNameFilter = string.IsNullOrEmpty(uniqueName) ? typeof(T).FullName : uniqueName;
 		}
 
 		/// <summary>
@@ -32,7 +32,18 @@ namespace Zyan.Communication
 		/// <summary>
 		/// Gets the unique name of the intercepted component.
 		/// </summary>
-		public string UniqueName { get; private set; }
+		public string UniqueNameFilter { get; private set; }
+
+		/// <summary>
+		/// Filters unique names with regex pattern.
+		/// </summary>
+		/// <param name="nameFilter"></param>
+		/// <returns></returns>
+		public CallInterceptorBuilder<T> WithUniqueNameFilter(string nameFilter)
+		{
+			UniqueNameFilter = nameFilter;
+			return this;
+		}
 
 		/// <summary>
 		/// Creates new CallInterceptor for the given method.
@@ -47,7 +58,7 @@ namespace Zyan.Communication
 			string memberName;
 			Parse(expression, out memberType, out memberName);
 
-			return new CallInterceptor(typeof(T), UniqueName, memberType, memberName, new Type[0], handler);
+			return new CallInterceptor(typeof(T), UniqueNameFilter, memberType, memberName, new Type[0], handler);
 		}
 
 		/// <summary>
@@ -63,7 +74,7 @@ namespace Zyan.Communication
 			string memberName;
 			Parse(expression, out memberType, out memberName);
 
-			return new CallInterceptor(typeof(T), UniqueName, memberType, memberName, new Type[0],
+			return new CallInterceptor(typeof(T), UniqueNameFilter, memberType, memberName, new Type[0],
 				data => data.ReturnValue = handler(data));
 		}
 

--- a/source/Zyan.Communication/CallInterceptorCollection.cs
+++ b/source/Zyan.Communication/CallInterceptorCollection.cs
@@ -63,7 +63,7 @@ namespace Zyan.Communication
 
 			var matchingInterceptors = this
 				.Where(ic => ic.Enabled)
-				.Where(ic => Regex.IsMatch(uniqueName, ic.UniqueNameFilter))
+				.Where(ic => ic.IsNameMatch(uniqueName))
 				.Where(ic => Equals(ic.InterfaceType, interfaceType))
 				.Where(ic => ic.MemberType == remotingMessage.MethodBase.MemberType)
 				.Where(ic => ic.MemberName == remotingMessage.MethodName)

--- a/source/Zyan.Communication/CallInterceptorCollection.cs
+++ b/source/Zyan.Communication/CallInterceptorCollection.cs
@@ -67,8 +67,7 @@ namespace Zyan.Communication
 				.Where(ic => Equals(ic.InterfaceType, interfaceType))
 				.Where(ic => ic.MemberType == remotingMessage.MethodBase.MemberType)
 				.Where(ic => ic.MemberName == remotingMessage.MethodName)
-				.Where(ic => GetTypeList(ic.ParameterTypes) == GetTypeList(remotingMessage.MethodBase.GetParameters()))
-				.ToList();
+				.Where(ic => GetTypeList(ic.ParameterTypes) == GetTypeList(remotingMessage.MethodBase.GetParameters()));
 
 			lock (SyncRoot)
 			{

--- a/source/Zyan.Communication/CallInterceptorHelper.cs
+++ b/source/Zyan.Communication/CallInterceptorHelper.cs
@@ -11,6 +11,7 @@ namespace Zyan.Communication
 	/// </summary>
 	public class CallInterceptorHelper<T> : IEnumerable<CallInterceptor>
 	{
+		private string _uniqueNameFilter;
 		CallInterceptorCollection Interceptors { get; set; }
 
 		/// <summary>
@@ -20,6 +21,20 @@ namespace Zyan.Communication
 		public CallInterceptorHelper(CallInterceptorCollection interceptors)
 		{
 			Interceptors = interceptors;
+		}
+
+		/// <summary>
+		/// Unique name regex filter. Once again... Some refactoring required.
+		/// </summary>
+		public string UniqueNameFilter
+		{
+			get
+			{
+				if (string.IsNullOrEmpty(_uniqueNameFilter))
+					return ".*";
+				return _uniqueNameFilter;
+			}
+			private set => _uniqueNameFilter = value;
 		}
 
 		/// <summary>
@@ -36,7 +51,8 @@ namespace Zyan.Communication
 			Parse(expression, out memberType, out memberName);
 
 			Interceptors.Add(new CallInterceptor(typeof(T),
-				memberType, memberName, new Type[0], handler));
+				memberType, memberName, new Type[0], handler)
+				.WithUniqueNameFilter(UniqueNameFilter));
 
 			return this;
 		}
@@ -57,7 +73,7 @@ namespace Zyan.Communication
 			Interceptors.Add(new CallInterceptor(typeof(T),
 				memberType, memberName, new Type[0],
 				data => data.ReturnValue = handler(data)
-			));
+			).WithUniqueNameFilter(UniqueNameFilter));
 
 			return this;
 		}
@@ -78,7 +94,7 @@ namespace Zyan.Communication
 			Interceptors.Add(new CallInterceptor(typeof(T),
 				memberType, memberName, new[] { typeof(T1) },
 				data => handler(data, (T1)data.Parameters[0])
-			));
+			).WithUniqueNameFilter(UniqueNameFilter));
 
 			return this;
 		}
@@ -99,7 +115,7 @@ namespace Zyan.Communication
 			Interceptors.Add(new CallInterceptor(typeof(T),
 				memberType, memberName, new[] { typeof(T1) },
 				data => data.ReturnValue = handler(data, (T1)data.Parameters[0])
-			));
+			).WithUniqueNameFilter(UniqueNameFilter));
 
 			return this;
 		}
@@ -120,7 +136,7 @@ namespace Zyan.Communication
 			Interceptors.Add(new CallInterceptor(typeof(T),
 				memberType, memberName, new[] { typeof(T1), typeof(T2) },
 				data => handler(data, (T1)data.Parameters[0], (T2)data.Parameters[1])
-			));
+			).WithUniqueNameFilter(UniqueNameFilter));
 
 			return this;
 		}
@@ -141,7 +157,7 @@ namespace Zyan.Communication
 			Interceptors.Add(new CallInterceptor(typeof(T),
 				memberType, memberName, new[] { typeof(T1), typeof(T2) },
 				data => data.ReturnValue = handler(data, (T1)data.Parameters[0], (T2)data.Parameters[1])
-			));
+			).WithUniqueNameFilter(UniqueNameFilter));
 
 			return this;
 		}
@@ -162,7 +178,7 @@ namespace Zyan.Communication
 			Interceptors.Add(new CallInterceptor(typeof(T),
 				memberType, memberName, new[] { typeof(T1), typeof(T2), typeof(T3) },
 				data => handler(data, (T1)data.Parameters[0], (T2)data.Parameters[1], (T3)data.Parameters[2])
-			));
+			).WithUniqueNameFilter(UniqueNameFilter));
 
 			return this;
 		}
@@ -183,8 +199,19 @@ namespace Zyan.Communication
 			Interceptors.Add(new CallInterceptor(typeof(T),
 				memberType, memberName, new[] { typeof(T1), typeof(T2), typeof(T3) },
 				data => data.ReturnValue = handler(data, (T1)data.Parameters[0], (T2)data.Parameters[1], (T3)data.Parameters[2])
-			));
+			).WithUniqueNameFilter(UniqueNameFilter));
 
+			return this;
+		}
+
+		/// <summary>
+		/// Feature to filter interceptor unique name.
+		/// </summary>
+		/// <param name="nameRegex"></param>
+		/// <returns></returns>
+		public CallInterceptorHelper<T> WithUniqueNameFilter(string nameRegex)
+		{
+			UniqueNameFilter = nameRegex;
 			return this;
 		}
 

--- a/source/Zyan.Communication/ZyanProxy.cs
+++ b/source/Zyan.Communication/ZyanProxy.cs
@@ -160,7 +160,7 @@ namespace Zyan.Communication
 			var interceptor = _connection.CallInterceptors.FindMatchingInterceptor(_interfaceType, _uniqueName, methodCallMessage);
 			if (interceptor != null && interceptor.OnInterception != null)
 			{
-				var interceptionData = new CallInterceptionData(methodCallMessage.Args, HandleRemoteInvocation, methodCallMessage);
+				var interceptionData = new CallInterceptionData(_uniqueName, methodCallMessage.Args, HandleRemoteInvocation, methodCallMessage);
 				interceptor.OnInterception(interceptionData);
 
 				if (interceptionData.Intercepted)


### PR DESCRIPTION
Hello guys:

Found and fixed a strange behavior when call interception mechanics works perfect with unnamed services but always failing for named services. Down there is slightly modified test code to reproduce the problem:

```
		[TestMethod]
		public void CallInterceptionBug()
		{
			using (var host = new ZyanComponentHost("FirstTestServer", 18888))
			{
				host.RegisterComponent<ITestService, TestService>("Blah", ActivationType.Singleton);

				using (var connection = new ZyanConnection("tcp://127.0.0.1:18888/FirstTestServer") { CallInterceptionEnabled = true })
				{
					// add a call interceptor for the TestService.TestMethod
					connection.CallInterceptors.Add(CallInterceptor.For<ITestService>().Action(service => service.TestMethod(), data =>
					{
						data.Intercepted = true;
						data.MakeRemoteCall();
						data.ReturnValue = nameof(TestService);
					}));

					var testService = connection.CreateProxy<ITestService>("Blah");
					var result = testService.TestMethod();
					Assert.AreEqual(nameof(TestService), result);
				}
			}
		}
```

Also implemented name filtering feature for CallInterceptor to specify unique via regex not by just equality compare to make interceptor declaration more flexible:
```
					connection.CallInterceptors.Add(CallInterceptor.For<ITestService>()
						.WithUniqueNameFilter(@"NamedService\d+")
						.Action(service => service.TestMethod(), data =>
						{
							data.ReturnValue = $"intercepted_{data.MakeRemoteCall()}";
							data.Intercepted = true;
						})); 
```
