### PR TITLE
Changes in the BasicWindowsAuthProvider

### DIFF
--- a/source/Zyan.Communication/Security/DomainHelper.cs
+++ b/source/Zyan.Communication/Security/DomainHelper.cs
@@ -1,0 +1,59 @@
+﻿namespace Zyan.Communication.Security
+{
+	/// <summary>
+	/// http://www.pinvoke.net/default.aspx/netapi32.NetGetJoinInformation
+	/// </summary>
+	public class DomainHelper
+	{
+		[System.Runtime.InteropServices.DllImport("Netapi32.dll", EntryPoint = "NetApiBufferFree")]
+		private static extern uint NetApiBufferFree(System.IntPtr buffer);
+		[System.Runtime.InteropServices.DllImport("Netapi32.dll", CharSet = System.Runtime.InteropServices.CharSet.Unicode, SetLastError = true)]
+		static extern int NetGetJoinInformation(string server, out System.IntPtr domain, out NetJoinStatus status);
+
+		/// <summary>
+		/// NetJoinStatus
+		/// </summary>
+		public enum NetJoinStatus
+		{
+			/// <summary>
+			/// unknown
+			/// </summary>
+			NetSetupUnknownStatus = 0,
+			/// <summary>
+			/// unjoined
+			/// </summary>
+			NetSetupUnjoined,
+			/// <summary>
+			/// workgroup
+			/// </summary>
+			NetSetupWorkgroupName,
+			/// <summary>
+			/// domain
+			/// </summary>
+			NetSetupDomainName
+		}
+
+		/// <summary>
+		/// Gets the name of the joined domain.		
+		/// </summary>
+		/// <returns></returns>
+		public static string GetJoinedDomainName()
+		{
+			string domainName = null;
+			var pDomain = System.IntPtr.Zero;
+			var status = NetJoinStatus.NetSetupUnknownStatus;
+			try
+			{
+				if ((NetGetJoinInformation(null, out pDomain, out status) == 0) && (status == NetJoinStatus.NetSetupDomainName))
+				{
+					domainName = System.Runtime.InteropServices.Marshal.PtrToStringAuto(pDomain);
+				}
+			}
+			finally
+			{
+				if (pDomain != System.IntPtr.Zero) NetApiBufferFree(pDomain);
+			}
+			 return ((domainName == null) ? "." : domainName);
+		}
+	}
+}

--- a/source/Zyan.Communication/Zyan.Communication.Fx3.csproj
+++ b/source/Zyan.Communication/Zyan.Communication.Fx3.csproj
@@ -276,6 +276,7 @@
     <Compile Include="Protocols\Versioning.cs" />
     <Compile Include="Security\AuthCredentials.cs" />
     <Compile Include="Security\BasicWindowsAuthProvider.cs" />
+    <Compile Include="Security\DomainHelper.cs" />
     <Compile Include="Security\Exceptions\AccountLockedException.cs" />
     <Compile Include="Security\Exceptions\AccountNotFoundException.cs" />
     <Compile Include="Security\Exceptions\PasswordExpiredException.cs" />


### PR DESCRIPTION
Hi @yallie ,

sorry for my delay.

Here are my changes for the "BasicWindowsAuthProvider":

- The authenticate method uses now the "GetWorkingUserName" function to determine the LDAP/AD user name. This method is virtual, so it is possible to use own logic for this task (e.g. map "Zyan user name" to "LDAP/AD user name").
-  I think, the domain name should be determined automatically on the server side, not in the client credentials. So i have created the "DomainHelper" class. With the "GetJoinedDomainName" function in the class it is possible to identify the domain name of the server. If the server is not in a domain, the result is ".".

Many greetings
heikar